### PR TITLE
Billing mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,15 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| attributes | List of nested attribute definitions. Only required for hash_key (always) and range_key (if used) attributes. Attributes have name and type. Type must be a scalar type: S, N, or B for (S)tring, (N)umber or (B)inary data. i.e. [{ name=<hash_key> type=<data_type>}] | list | n/a | yes |
-| hash\_key | ** Forces new resource ** Must contain only alphanumberic characters, dash (-), underscore (_) or dot (.). Needs to be defined by type in attributes. | string | n/a | yes |
-| point\_in\_time\_recovery | Enable point in time recovery for the table. | string | `"false"` | no |
-| range\_key | ** Forces new resource ** RangeType PrimaryKey Name. If used, it will need to be defined by type in attributes | string | `""` | no |
-| read\_capacity\_units | Provisioned read throughput. Should be between 5 and 10000 | string | `"5"` | no |
-| table\_encryption | Server side table encryption at rest. i.e. true | false | string | `"true"` | no |
-| table\_name | The name of the table, this needs to be unique within a region. | string | n/a | yes |
-| write\_capacity\_units | Provisioned write throughput. Should be between 5 and 10000. | string | `"10"` | no |
+| attributes | List of nested attribute definitions. Only required for hash_key (always) and range_key (if used) attributes. Attributes have name and type. Type must be a scalar type: S, N, or B for (S)tring, (N)umber or (B)inary data. i.e. [{ name=<hash_key> type=<data_type>}] | list | - | yes |
+| enable\_pay\_per\_request | Controls how you are charged for read and write throughput and how you manage capacity. If True, DynamoDB charges you for the data reads and writes your application performs on your tables. You do not need to specify how much read and write throughput you expect your application to perform because DynamoDB instantly accommodates your workloads as they ramp up or down. [On-Demand Pricing](https://aws.amazon.com/dynamodb/pricing/on-demand/) If False, you specify the number of `read_capacity_units` and `write_capacity_units` per second that you expect your workload to require. [Provisioned Pricing](https://aws.amazon.com/dynamodb/pricing/provisioned/) | string | `false` | no |
+| hash\_key | ** Forces new resource ** Must contain only alphanumberic characters, dash (-), underscore (_) or dot (.). Needs to be defined by type in attributes. | string | - | yes |
+| point\_in\_time\_recovery | Enable point in time recovery for the table. | string | `false` | no |
+| range\_key | ** Forces new resource ** RangeType PrimaryKey Name. If used, it will need to be defined by type in attributes | string | `` | no |
+| read\_capacity\_units | Provisioned read throughput. Should be between 5 and 10000. Ignored if `enable_pay_per_request` is set to `true`. | string | `5` | no |
+| table\_encryption | Server side table encryption at rest. i.e. true | false | string | `true` | no |
+| table\_name | The name of the table, this needs to be unique within a region. | string | - | yes |
+| write\_capacity\_units | Provisioned write throughput. Should be between 5 and 10000. Ignored if `enable_pay_per_request` is set to `true`. | string | `10` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| attributes | List of nested attribute definitions. Only required for hash_key (always) and range_key (if used) attributes. Attributes have name and type. Type must be a scalar type: S, N, or B for (S)tring, (N)umber or (B)inary data. i.e. [{ name=<hash_key> type=<data_type>}] | list | - | yes |
-| enable\_pay\_per\_request | Controls how you are charged for read and write throughput and how you manage capacity. If True, DynamoDB charges you for the data reads and writes your application performs on your tables. You do not need to specify how much read and write throughput you expect your application to perform because DynamoDB instantly accommodates your workloads as they ramp up or down. [On-Demand Pricing](https://aws.amazon.com/dynamodb/pricing/on-demand/) If False, you specify the number of `read_capacity_units` and `write_capacity_units` per second that you expect your workload to require. [Provisioned Pricing](https://aws.amazon.com/dynamodb/pricing/provisioned/) | string | `false` | no |
-| hash\_key | ** Forces new resource ** Must contain only alphanumberic characters, dash (-), underscore (_) or dot (.). Needs to be defined by type in attributes. | string | - | yes |
-| point\_in\_time\_recovery | Enable point in time recovery for the table. | string | `false` | no |
-| range\_key | ** Forces new resource ** RangeType PrimaryKey Name. If used, it will need to be defined by type in attributes | string | `` | no |
-| read\_capacity\_units | Provisioned read throughput. Should be between 5 and 10000. Ignored if `enable_pay_per_request` is set to `true`. | string | `5` | no |
-| table\_encryption | Server side table encryption at rest. i.e. true | false | string | `true` | no |
-| table\_name | The name of the table, this needs to be unique within a region. | string | - | yes |
-| write\_capacity\_units | Provisioned write throughput. Should be between 5 and 10000. Ignored if `enable_pay_per_request` is set to `true`. | string | `10` | no |
+| attributes | List of nested attribute definitions. Only required for hash_key (always) and range_key (if used) attributes. Attributes have name and type. Type must be a scalar type: S, N, or B for (S)tring, (N)umber or (B)inary data. i.e. [{ name=<hash_key> type=<data_type>}] | list | n/a | yes |
+| enable\_pay\_per\_request | Controls how you are charged for read and write throughput and how you manage capacity. If True, DynamoDB charges you for the data reads and writes your application performs on your tables. You do not need to specify how much read and write throughput you expect your application to perform because DynamoDB instantly accommodates your workloads as they ramp up or down. [On-Demand Pricing](https://aws.amazon.com/dynamodb/pricing/on-demand/) If False, you specify the number of `read_capacity_units` and `write_capacity_units` per second that you expect your workload to require. [Provisioned Pricing](https://aws.amazon.com/dynamodb/pricing/provisioned/) | string | `"false"` | no |
+| hash\_key | ** Forces new resource ** Must contain only alphanumberic characters, dash (-), underscore (_) or dot (.). Needs to be defined by type in attributes. | string | n/a | yes |
+| point\_in\_time\_recovery | Enable point in time recovery for the table. | string | `"false"` | no |
+| range\_key | ** Forces new resource ** RangeType PrimaryKey Name. If used, it will need to be defined by type in attributes | string | `""` | no |
+| read\_capacity\_units | Provisioned read throughput. Should be between 5 and 10000. Ignored if `enable_pay_per_request` is set to `true`. | string | `"5"` | no |
+| table\_encryption | Server side table encryption at rest. i.e. true | false | string | `"true"` | no |
+| table\_name | The name of the table, this needs to be unique within a region. | string | n/a | yes |
+| write\_capacity\_units | Provisioned write throughput. Should be between 5 and 10000. Ignored if `enable_pay_per_request` is set to `true`. | string | `"10"` | no |
 
 ## Outputs
 

--- a/examples/example.tf
+++ b/examples/example.tf
@@ -3,14 +3,39 @@ provider "aws" {
   region  = "us-west-2"
 }
 
-module "dynamo" {
-  source = "git@github.com/rackspace-infrastructure-automation/aws-terraform-dynamo//?ref=v0.0.1"
+module "dynamo_table_provisioned" {
+  source = "git@github.com/rackspace-infrastructure-automation/aws-terraform-dynamo//?ref=v0.0.2"
 
-  table_name           = "<TableName>"
-  hash_key             = "<HashKeyName>"
-  range_key            = "<RangeKey>"
-  read_capacity_units  = 5
-  write_capacity_units = 10
+  table_name             = "<TableName>"
+  hash_key               = "<HashKeyName>"
+  range_key              = "<RangeKey>"
+  enable_pay_per_request = false
+  read_capacity_units    = 5
+  write_capacity_units   = 10
+
+  attributes = [
+    {
+      name = "<HashKeyName>"
+      type = "S"
+    },
+    {
+      name = "<RangeKey>"
+      type = "N"
+    },
+  ]
+
+  table_encryption = true
+
+  point_in_time_recovery = true
+}
+
+module "dynamo_table_pay_per_requst" {
+  source = "git@github.com/rackspace-infrastructure-automation/aws-terraform-dynamo//?ref=v0.0.2"
+
+  table_name             = "<TableName>"
+  hash_key               = "<HashKeyName>"
+  range_key              = "<RangeKey>"
+  enable_pay_per_request = true
 
   attributes = [
     {

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,6 @@
 resource "aws_dynamodb_table" "basic-dynamodb-table" {
   name           = "${var.table_name}"
+  billing_mode   = "${var.enable_pay_per_request ? "PAY_PER_REQUEST":"PROVISIONED"}"
   read_capacity  = "${var.read_capacity_units}"
   write_capacity = "${var.write_capacity_units}"
   hash_key       = "${var.hash_key}"

--- a/variables.tf
+++ b/variables.tf
@@ -3,6 +3,12 @@ variable "table_name" {
   type        = "string"
 }
 
+variable "enable_pay_per_request" {
+  description = "Controls how you are charged for read and write throughput and how you manage capacity. If True, DynamoDB charges you for the data reads and writes your application performs on your tables. You do not need to specify how much read and write throughput you expect your application to perform because DynamoDB instantly accommodates your workloads as they ramp up or down. [On-Demand Pricing](https://aws.amazon.com/dynamodb/pricing/on-demand/) If False, you specify the number of `read_capacity_units` and `write_capacity_units` per second that you expect your workload to require. [Provisioned Pricing](https://aws.amazon.com/dynamodb/pricing/provisioned/)"
+  type        = "string"
+  default     = false
+}
+
 variable "hash_key" {
   description = "** Forces new resource ** Must contain only alphanumberic characters, dash (-), underscore (_) or dot (.). Needs to be defined by type in attributes."
   type        = "string"
@@ -15,7 +21,7 @@ variable "range_key" {
 }
 
 variable "read_capacity_units" {
-  description = "Provisioned read throughput. Should be between 5 and 10000"
+  description = "Provisioned read throughput. Should be between 5 and 10000. Ignored if `enable_pay_per_request` is set to `true`."
   type        = "string"
   default     = 5
 }
@@ -27,7 +33,7 @@ variable "table_encryption" {
 }
 
 variable "write_capacity_units" {
-  description = "Provisioned write throughput. Should be between 5 and 10000."
+  description = "Provisioned write throughput. Should be between 5 and 10000. Ignored if `enable_pay_per_request` is set to `true`."
   type        = "string"
   default     = 10
 }


### PR DESCRIPTION
##### Corresponding Issue(s) or trello card(s):
https://trello.com/c/XIk0O96k/1192-add-billing-method-to-dynamo-module-to-allow-for-provisioned-or-pay-per-request-tables

##### Summary of change(s):
Allows you to select provisioned or pay-per-request billing methods for the table.

There is currently an issue where you can not convert a pay-per-request to provisioned table. Should be fixed in the next release or so of the aws provider. https://github.com/terraform-providers/terraform-provider-aws/pull/7363

Changing from provisioned to pay-per-request works correctly.

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:

no.

##### Does this update/change involve issues with other external modules? If so, please describe the scenario.
no

##### If input variables or output variables have changed or has been added, have you updated the README?
yes

##### Do examples need to be updated based on changes?
yes


##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.