### PR TITLE
Resolve repeated reapplys when using PAY_PER_REQUEST mode

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -61,10 +61,10 @@ resource "aws_dynamodb_table" "basic-dynamodb-table" {
   hash_key         = "${var.hash_key}"
   name             = "${var.table_name}"
   range_key        = "${var.range_key}"
-  read_capacity    = "${var.read_capacity_units}"
+  read_capacity    = "${var.enable_pay_per_request ? 0 : var.read_capacity_units}"
   stream_enabled   = "${var.stream_enabled}"
   stream_view_type = "${var.stream_enabled ? var.stream_view_type : "" }"
-  write_capacity   = "${var.write_capacity_units}"
+  write_capacity   = "${var.enable_pay_per_request ? 0 : var.write_capacity_units}"
 
   attribute              = "${var.attributes}"
   global_secondary_index = "${var.global_secondary_index_maps}"


### PR DESCRIPTION
##### Corresponding Issue(s) or trello card(s):
NA
##### Summary of change(s):
Adds logic to set `read_capacity` and `write_capacity` to `0` when PAY_PER_REQUEST mode is used on the table.  Previous behavior, every subsequent plan or apply would try to reset these properties to the default values.
##### Will the change trigger resource destruction or replacement? If yes, please provide justification:
No
##### Does this update/change involve issues with other external modules? If so, please describe the scenario.
No
##### If input variables or output variables have changed or has been added, have you updated the README?
NA
##### Do examples need to be updated based on changes?
No
##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.