### PR TITLE
Fix output to use bool instead of string for stream_arn

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This module creates an AWS DynamoDB table.
 
 ```HCL
 module "basic" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-dynamo/?ref=v0.12.0"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-dynamo/?ref=v0.12.2"
 
   environment          = "Test"
   hash_key             = "MyHashKey"

--- a/examples/example.tf
+++ b/examples/example.tf
@@ -8,7 +8,7 @@ provider "aws" {
 }
 
 module "dynamo_table_provisioned" {
-  source = "git@github.com/rackspace-infrastructure-automation/aws-terraform-dynamo//?ref=v0.12.0"
+  source = "git@github.com/rackspace-infrastructure-automation/aws-terraform-dynamo//?ref=v0.12.2"
 
   enable_pay_per_request = false
   hash_key               = "<HashKeyName>"
@@ -32,7 +32,7 @@ module "dynamo_table_provisioned" {
 }
 
 module "dynamo_table_pay_per_requst" {
-  source = "git@github.com/rackspace-infrastructure-automation/aws-terraform-dynamo//?ref=v0.12.0"
+  source = "git@github.com/rackspace-infrastructure-automation/aws-terraform-dynamo//?ref=v0.12.2"
 
   enable_pay_per_request = true
   hash_key               = "<HashKeyName>"
@@ -52,4 +52,3 @@ module "dynamo_table_pay_per_requst" {
     },
   ]
 }
-

--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,7 @@
  *
  * ```HCL
  * module "basic" {
- *   source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-dynamo/?ref=v0.12.0"
+ *   source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-dynamo/?ref=v0.12.2"
  *
  *   environment          = "Test"
  *   hash_key             = "MyHashKey"
@@ -134,4 +134,3 @@ resource "aws_dynamodb_table" "table" {
     attribute_name = var.ttl_attribute
   }
 }
-

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,6 @@
 output "stream_arn" {
   description = "ARN for the stream if `stream_enabled` was set to `true`, otherwise returns a string of \"null\"."
-  value       = var.stream_enabled == "true" ? aws_dynamodb_table.table.stream_arn : "null"
+  value       = var.stream_enabled ? aws_dynamodb_table.table.stream_arn : "null"
 }
 
 output "table_arn" {
@@ -12,4 +12,3 @@ output "table_name" {
   description = "Table Name"
   value       = aws_dynamodb_table.table.id
 }
-


### PR DESCRIPTION
##### Corresponding Issue(s):
<!-- - PRs should have a corresponding issue. If no issue exists, provide details in the **Reason for Change(s)** section -->

N/A

##### Summary of change(s):

- fix `stream_arn` output to use bool instead of string in conditional

##### Reason for Change(s):

<!-- - If a bug, describe error scenario, including expected behavior and actual behavior. -->

<!-- - If an enhancement, describe the use case and the perceived benefit(s). -->

Customer using `stream_enabled = true` was getting `stream_arn = "null"` back.

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:

No

##### Does this update/change involve issues with other external modules? If so, please describe the scenario.

No

##### If input variables or output variables have changed or has been added, have you updated the README?

No

##### Do examples need to be updated based on changes?

Done for v0.12.2 tag

##### Note to the PR requester about Closing PR's

Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.
